### PR TITLE
Properly dealloc webview on iOS to prevent crashes

### DIFF
--- a/ios/Classes/DkNappJockeyWebView.m
+++ b/ios/Classes/DkNappJockeyWebView.m
@@ -11,6 +11,23 @@
 
 @implementation DkNappJockeyWebView
 
+-(void)dealloc
+{
+    if (webview!=nil)
+    {
+        webview.delegate = nil;
+        
+        // per doc, must stop webview load before releasing
+        if (webview.loading)
+        {
+            [webview stopLoading];
+        }
+    }
+    RELEASE_TO_NIL(webview);
+    RELEASE_TO_NIL(url);
+    RELEASE_TO_NIL(lastValidLoad);
+    [super dealloc];
+}
 
 -(UIWebView*)webview
 {


### PR DESCRIPTION
My app was crashing when using DkNappJockeyWebView but worked fine with TiUIWebView so I looked at their implementation and added dealloc. Has fixed my crashing issue so far.
