### PR TITLE
Fix crash when re-launching activity on Android, closes #4

### DIFF
--- a/android/src/dk/napp/jockey/DkNappJockeyWebViewProxy.java
+++ b/android/src/dk/napp/jockey/DkNappJockeyWebViewProxy.java
@@ -51,15 +51,9 @@ public class DkNappJockeyWebViewProxy extends TiViewProxy
 	}
 
 	@Override
-	public TiUIView createView(Activity arg0) {
-		initView();
+	public TiUIView createView(Activity activity) {
+		webView = new DkNappJockeyWebView(this);
 		return webView;
-	}
-
-	private void initView() {
-		if (webView == null) {
-			webView = new DkNappJockeyWebView(this);
-		}
 	}
 	
 	public DkNappJockeyWebView getWebView()


### PR DESCRIPTION
Found the issue after a lot of experimenting. Can you build new dist's for iOS and Android after merging?
